### PR TITLE
Update webview import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, WebView } from 'react-native';
+import { View } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 var js = `
 	var haveEvents = 'GamepadEvent' in window;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-native-gamepad-controller",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "A react-native component to interface with gamepads/joysticks/controllers without using native code.",
 	"main": "index.js",
 	"repository": {
@@ -21,6 +21,7 @@
 	},
 	"homepage": "https://github.com/domstoppable/react-native-gamepad-controller",
 	"dependencies": {
-		"react": "16.3.1"
+		"react": "16.3.1",
+		"react-native-webview": "11.6.2"
 	}
 }


### PR DESCRIPTION
Import webview from react-native-webview instead of react-native

`Invariant Violation: WebView has been removed from React Native. It can now be installed and imported from 'react-native-webview' instead of 'react-native'. `